### PR TITLE
Create WATCH-LIVE]] Martin Bakole vs. Joseph Parker.md

### DIFF
--- a/WATCH-LIVE]] Martin Bakole vs. Joseph Parker.md
+++ b/WATCH-LIVE]] Martin Bakole vs. Joseph Parker.md
@@ -1,0 +1,50 @@
+The much-anticipated rematch between Artur Beterbiev and Dmitry Bivol promises to be an electrifying event in the world of boxing. With both fighters holding the world’s light-heavyweight titles, their showdown is expected to be a thrilling contest of power and skill. Here’s everything you need to know about how to stream this highly anticipated battle, so you don’t miss a minute of the action.
+
+🅻🅸🆅🅴🔴▶️ https://cutt.ly/1rwct6c5
+
+🆆🅰🆃🅲🅷🔴▶️ https://cutt.ly/1rwct6c5
+
+Event Details:
+Fight Date: Saturday, February 22, 2025
+Location: Kingdom Arena, Riyadh, Saudi Arabia
+Main Event Start Time: Around 11:00 PM UK time (6:00 PM ET)
+Undercard Time: Main card begins at 3:30 PM UK time (10:30 AM ET)
+Where to Watch:
+
+DAZN (US & International)
+The fight will be available for streaming on DAZN in both the US and internationally. A subscription to DAZN is required, but new subscribers can enjoy a 7-day free trial to watch the fight. For those in the US, DAZN offers a pay-per-view option priced at $25.99 for the Beterbiev vs. Bivol 2 event.
+Subscription Options: DAZN subscription (monthly or annual) required, or PPV for this specific fight.
+Cost: $25.99 for the PPV event in the US.
+2. Sky Sports Box Office & DAZN (UK)
+For viewers in the UK, Sky Sports Box Office and DAZN will provide the streaming options for the fight. The PPV price for UK viewers is set at £19.99, and this will cover the entire event, including undercard fights.
+
+Subscription Options: Sky Sports Box Office or DAZN.
+Cost: £19.99 for UK viewers.
+3. TNT Sports Box Office (UK)
+Another UK-based option is TNT Sports Box Office, which will also broadcast the event. This option is another way for fans to catch the action from the comfort of their homes.
+
+Subscription Options: TNT Sports Box Office.
+Cost: £19.99 for UK viewers.
+What You Need to Watch:
+Subscription: Whether you choose DAZN or another broadcaster, ensure you have an active subscription.
+Device Compatibility: Check that your device (smartphone, tablet, laptop, or smart TV) is compatible with the streaming service’s app or website.
+Stable Internet: Since the event will be streamed live, make sure you have a reliable internet connection to avoid buffering or interruptions.
+Undercard Fights:
+Alongside the Beterbiev vs. Bivol 2 rematch, several exciting undercard bouts are scheduled. These include:
+
+Joseph Parker vs. Martin Bakole – Heavyweight Bout
+Shakur Stevenson vs. Josh Padley – Lightweight Title Fight
+Carlos Adames vs. Hamzah Sheeraz – Middleweight Title Fight
+Vergil Ortiz Jr. vs. Israil Madrimov – Super Welterweight Title Fight
+Zhilei Zhang vs. Agit Kabayel – Heavyweight Bout
+Joshua Buatsi vs. Callum Smith – Light Heavyweight Bout
+These matches promise to add more drama and excitement leading up to the main event, making this one of the most thrilling nights in boxing.
+
+How to Prepare:
+Check Time Zones: Be mindful of the event’s local time in Riyadh and adjust for your time zone so you don’t miss out on the action.
+Create Your Streaming Account in Advance: Ensure you set up your DAZN or other broadcaster account ahead of time to avoid any last-minute issues.
+Test Your Equipment: Make sure your TV, laptop, or mobile device is ready for streaming. Download the necessary app (e.g., DAZN app) and log in to your account before the event begins.
+Conclusion:
+Whether you’re in the US, UK, or elsewhere, streaming Artur Beterbiev vs. Dmitry Bivol 2 is simple and accessible via platforms like DAZN and Sky Sports Box Office. With the undercard offering some exciting matchups, this event is shaping up to be a night of top-tier boxing action.
+
+Don’t miss the chance to watch two of the sport’s best light-heavyweights battle for supremacy!


### PR DESCRIPTION
The much-anticipated rematch between Artur Beterbiev and Dmitry Bivol promises to be an electrifying event in the world of boxing. With both fighters holding the world’s light-heavyweight titles, their showdown is expected to be a thrilling contest of power and skill. Here’s everything you need to know about how to stream this highly anticipated battle, so you don’t miss a minute of the action.

🅻🅸🆅🅴🔴▶️ https://cutt.ly/1rwct6c5

🆆🅰🆃🅲🅷🔴▶️ https://cutt.ly/1rwct6c5

Event Details:
Fight Date: Saturday, February 22, 2025
Location: Kingdom Arena, Riyadh, Saudi Arabia
Main Event Start Time: Around 11:00 PM UK time (6:00 PM ET)
Undercard Time: Main card begins at 3:30 PM UK time (10:30 AM ET)
Where to Watch:

DAZN (US & International)
The fight will be available for streaming on DAZN in both the US and internationally. A subscription to DAZN is required, but new subscribers can enjoy a 7-day free trial to watch the fight. For those in the US, DAZN offers a pay-per-view option priced at $25.99 for the Beterbiev vs. Bivol 2 event.
Subscription Options: DAZN subscription (monthly or annual) required, or PPV for this specific fight.
Cost: $25.99 for the PPV event in the US.
2. Sky Sports Box Office & DAZN (UK)
For viewers in the UK, Sky Sports Box Office and DAZN will provide the streaming options for the fight. The PPV price for UK viewers is set at £19.99, and this will cover the entire event, including undercard fights.

Subscription Options: Sky Sports Box Office or DAZN.
Cost: £19.99 for UK viewers.
3. TNT Sports Box Office (UK)
Another UK-based option is TNT Sports Box Office, which will also broadcast the event. This option is another way for fans to catch the action from the comfort of their homes.

Subscription Options: TNT Sports Box Office.
Cost: £19.99 for UK viewers.
What You Need to Watch:
Subscription: Whether you choose DAZN or another broadcaster, ensure you have an active subscription.
Device Compatibility: Check that your device (smartphone, tablet, laptop, or smart TV) is compatible with the streaming service’s app or website.
Stable Internet: Since the event will be streamed live, make sure you have a reliable internet connection to avoid buffering or interruptions.
Undercard Fights:
Alongside the Beterbiev vs. Bivol 2 rematch, several exciting undercard bouts are scheduled. These include:

Joseph Parker vs. Martin Bakole – Heavyweight Bout
Shakur Stevenson vs. Josh Padley – Lightweight Title Fight
Carlos Adames vs. Hamzah Sheeraz – Middleweight Title Fight
Vergil Ortiz Jr. vs. Israil Madrimov – Super Welterweight Title Fight
Zhilei Zhang vs. Agit Kabayel – Heavyweight Bout
Joshua Buatsi vs. Callum Smith – Light Heavyweight Bout
These matches promise to add more drama and excitement leading up to the main event, making this one of the most thrilling nights in boxing.

How to Prepare:
Check Time Zones: Be mindful of the event’s local time in Riyadh and adjust for your time zone so you don’t miss out on the action.
Create Your Streaming Account in Advance: Ensure you set up your DAZN or other broadcaster account ahead of time to avoid any last-minute issues.
Test Your Equipment: Make sure your TV, laptop, or mobile device is ready for streaming. Download the necessary app (e.g., DAZN app) and log in to your account before the event begins.
Conclusion:
Whether you’re in the US, UK, or elsewhere, streaming Artur Beterbiev vs. Dmitry Bivol 2 is simple and accessible via platforms like DAZN and Sky Sports Box Office. With the undercard offering some exciting matchups, this event is shaping up to be a night of top-tier boxing action.

Don’t miss the chance to watch two of the sport’s best light-heavyweights battle for supremacy!