### PR TITLE
Create Shakur Stevenson vs. Josh Padley Live Coverage.md

### DIFF
--- a/Shakur Stevenson vs. Josh Padley Live Coverage.md
+++ b/Shakur Stevenson vs. Josh Padley Live Coverage.md
@@ -1,0 +1,33 @@
+MMA Fighting has Beterbiev vs. Bivol 2 results live for the Artur Beterbiev vs. Dmitry Bivol fight card at the Kingdom Arena in Riyadh, Saudi Arabia, on Saturday.
+
+When the main event begins around 6 p.m. ET, check out our Beterbiev vs. Bivol 2 live round-by-round updates for our live blog of the main event. Artur Beterbiev defeated Dmitry Bivol via majority decision this past October.
+
+Main Card (DAZN/PPV.com live now)
+
+Artur Beterbiev vs. Dmitry Bivol (live blog)
+
+Martin Bakole vs. Joseph Parker
+
+Shakur Stevenson vs. Josh Padley
+
+Carlos Adames vs. Hamzah Sheeraz
+
+Vergil Ortiz Jr. vs. Israil Madrimov
+
+Agit Kabayel def. Zhilei Zhang via KO (R6, 2:29) | Watch finish
+
+Callum Smith def. Joshua Buatsi via unanimous decision (119-110, 115-113, 116-112)
+
+Preliminary Card
+
+Ziyad Almaayouf def. Jonatas Oliveira via decision (60-54)
+
+Mohammed Alakel def. Engel Gomez via decision (60-54)
+
+Check out Beterbiev vs. Bivol 2 undercard live blog below:
+
+Our first title fight of the next is set to go, with Joshua Buatsi defending an interim WBO light heavyweight title against Callum Smith.
+
+Latest Video from SB Nation
+
+View MoreView Less


### PR DESCRIPTION
MMA Fighting has Beterbiev vs. Bivol 2 results live for the Artur Beterbiev vs. Dmitry Bivol fight card at the Kingdom Arena in Riyadh, Saudi Arabia, on Saturday.

When the main event begins around 6 p.m. ET, check out our Beterbiev vs. Bivol 2 live round-by-round updates for our live blog of the main event. Artur Beterbiev defeated Dmitry Bivol via majority decision this past October.

Main Card (DAZN/PPV.com live now)

Artur Beterbiev vs. Dmitry Bivol (live blog)

Martin Bakole vs. Joseph Parker

Shakur Stevenson vs. Josh Padley

Carlos Adames vs. Hamzah Sheeraz

Vergil Ortiz Jr. vs. Israil Madrimov

Agit Kabayel def. Zhilei Zhang via KO (R6, 2:29) | Watch finish

Callum Smith def. Joshua Buatsi via unanimous decision (119-110, 115-113, 116-112)

Preliminary Card

Ziyad Almaayouf def. Jonatas Oliveira via decision (60-54)

Mohammed Alakel def. Engel Gomez via decision (60-54)

Check out Beterbiev vs. Bivol 2 undercard live blog below:

Our first title fight of the next is set to go, with Joshua Buatsi defending an interim WBO light heavyweight title against Callum Smith.

Latest Video from SB Nation

View MoreView Less
